### PR TITLE
Calculate outline in Blender

### DIFF
--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -2349,13 +2349,13 @@ class Export3DMigotoGenshin(bpy.types.Operator, ExportHelper):
 
     overlapping_faces : BoolProperty(
         name="Ignore overlapping faces",
-        description="Detect and ignore overlapping faces to avoid buggy outlines. Recommended if you have overlaps. Slow",
+        description="Detect and ignore overlapping faces to avoid buggy outlines. Recommended if you have overlaps. Extremely Slow",
         default=False,
     )
 
     detect_edges : BoolProperty(
         name="Calculate edges",
-        description="Calculate for disconnected edges when rounding, closing holes in the edge outline. Slower",
+        description="Calculate for disconnected edges when rounding, closing holes in the edge outline. Slow",
         default=False,
     )
 

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -1521,9 +1521,9 @@ def export_3dmigoto_genshin(operator, context, object_name, vb_path, ib_path, fm
                     verts_obj = mesh.vertices
                     Pos_Same_Vertices = {}
                     Pos_Close_Vertices = {}
-
-                    i_nedd = min(precision(nearest_edge_distance), decimal_rounding_outline) - 1
-                    i_nedd_increment =  1**(-i_nedd)
+                    if detect_edges and toggle_rounding_outline:
+                        i_nedd = min(precision(nearest_edge_distance), decimal_rounding_outline) - 1
+                        i_nedd_increment =  1**(-i_nedd)
                     
                     for poly in mesh.polygons:
                         face_vertices = list(poly.vertices)
@@ -1615,7 +1615,6 @@ def export_3dmigoto_genshin(operator, context, object_name, vb_path, ib_path, fm
                         if not calculate_all_faces and len(vertex_group) == 1: continue
                         
                         FacesConnectedbySameVertex = Precalculated_Outline_data.get('Connected_Faces_bySameVertex').get(key)
-                        ConnectedFaces = [mesh.polygons[x].vertices for x in FacesConnectedbySameVertex]
                         ConnectedWeightedNormal = []
                                   
                         if overlapping_faces:

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -1119,7 +1119,7 @@ def antiparallel(t):
     return numpy.dot(fn1,fn2) == -1
 
 def precision(x): 
-    return -numpy.floor(numpy.log10(x))
+    return -int(numpy.floor(numpy.log10(x)))
 
 def recursive_connections(Over2_connected_points):
     for entry, connectedpointentry in Over2_connected_points.items():

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -2360,13 +2360,13 @@ class Export3DMigotoGenshin(bpy.types.Operator, ExportHelper):
 
     angle_weighted : BoolProperty(
         name="Weight by angle",
-        description="Calculate angles to improve accuracy of outlines. Slow",
+        description="Calculate angles to improve accuracy of outlines",
         default=False,
     )
 
     overlapping_faces : BoolProperty(
         name="Ignore overlapping faces",
-        description="Detect and ignore overlapping faces to avoid buggy outlines. Recommended if you have overlaps. Extremely Slow",
+        description="Detect and ignore overlapping faces to avoid buggy outlines. Recommended if you have overlaps",
         default=False,
     )
 
@@ -2378,14 +2378,14 @@ class Export3DMigotoGenshin(bpy.types.Operator, ExportHelper):
 
     calculate_all_faces : BoolProperty(
         name="Calculate outline for all faces",
-        description="If you have any flat shaded internal faces or if you just need to fix outline for all faces, turn on this option for better outlines. Very slow",
+        description="If you have any flat shaded internal faces or if you just need to fix outline for all faces, turn on this option for better outlines. Slow",
         default=False,
     )
 
     nearest_edge_distance : bpy.props.FloatProperty(
         name="Distance:",
         description="Expand grouping for edge vertices within this radial distance to close holes in the edge outline. Requires rounding",
-        default=0.005,
+        default=0.001,
         soft_min=0,
         precision=4,
     )

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -1558,21 +1558,24 @@ def export_3dmigoto_genshin(operator, context, object_name, vb_path, ib_path, fm
                             if not checkEnclosedFacesVertex(ConnectedFaces, vertex_group, Precalculated_Outline_data):
 
                                 for vertex in vertex_group:
-                                    Precalculated_Outline_data.get('RepositionLocal').add(vertex)
                                     p1, p2, p3 = verts_obj[vertex].undeformed_co
-                                    p1n = p1+nearest_edge_distance
-                                    p1nn = p1-nearest_edge_distance
-                                    p2n = p2+nearest_edge_distance
-                                    p2nn = p2-nearest_edge_distance
-                                    p3n = p3+nearest_edge_distance
-                                    p3nn = p3-nearest_edge_distance
-                                    
                                     closest_group = Pos_Close_Vertices.get((round(p1, i_nedd), round(p2, i_nedd), round(p3, i_nedd)))
 
-                                    for v_closest_pos in closest_group:
-                                        o1, o2, o3 = verts_obj[v_closest_pos].undeformed_co
-                                        if p1n >= o1 >= p1nn and p2n >= o2 >= p2nn and p3n >= o3 >= p3nn:
-                                            Precalculated_Outline_data.get('Same_Vertex').get(vertex).add(v_closest_pos)
+                                    if closest_group:
+                                        Precalculated_Outline_data.get('RepositionLocal').add(vertex)
+                                        
+                                        p1n = p1+nearest_edge_distance
+                                        p1nn = p1-nearest_edge_distance
+                                        p2n = p2+nearest_edge_distance
+                                        p2nn = p2-nearest_edge_distance
+                                        p3n = p3+nearest_edge_distance
+                                        p3nn = p3-nearest_edge_distance
+                                                    
+                                        for v_closest_pos in closest_group:
+                                            o1, o2, o3 = verts_obj[v_closest_pos].undeformed_co
+                                            if p1n >= o1 >= p1nn and p2n >= o2 >= p2nn and p3n >= o3 >= p3nn:
+                                                Precalculated_Outline_data.get('Same_Vertex').get(vertex).add(v_closest_pos)
+                                    else: break
                     
                     for key, value in Precalculated_Outline_data.get('Same_Vertex').items():
                         
@@ -1588,9 +1591,7 @@ def export_3dmigoto_genshin(operator, context, object_name, vb_path, ib_path, fm
 
                         if key in IteratedValues: continue
 
-                        if len(vertex_group) == 1:
-                            if not calculate_all_faces:
-                                continue
+                        if not calculate_all_faces and len(vertex_group) == 1: continue
                         
                         FacesConnectedbySameVertex = Precalculated_Outline_data.get('Connected_Faces_bySameVertex').get(key)
                         ConnectedFaces = [mesh.polygons[x].vertices for x in FacesConnectedbySameVertex]
@@ -2349,7 +2350,7 @@ class Export3DMigotoGenshin(bpy.types.Operator, ExportHelper):
     nearest_edge_distance : bpy.props.FloatProperty(
         name="Distance:",
         description="Expand grouping for edge vertices within this radial distance to close holes in the edge outline. Requires rounding",
-        default=0.002,
+        default=0.005,
         soft_min=0,
         precision=4,
     )

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -2337,7 +2337,7 @@ class Export3DMigotoGenshin(bpy.types.Operator, ExportHelper):
 
     detect_edges : BoolProperty(
         name="Calculate edges",
-        description="Calculate for disconnected edges when rounding, closing holes in the edge outline. Slow",
+        description="Calculate for disconnected edges when rounding, closing holes in the edge outline. Very slow",
         default=False,
     )
 

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -1640,7 +1640,7 @@ def export_3dmigoto_genshin(operator, context, object_name, vb_path, ib_path, fm
                         wSum = unit_vector(sum(ConnectedWeightedNormal)).tolist()
 
                         if wSum != [0,0,0]:
-                            if key in RepositionLocal:
+                            if RepositionLocal and key in RepositionLocal:
                                 export_Outline.setdefault(key, wSum)
                                 continue
                             for vertexf in vertex_group:

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -1119,10 +1119,7 @@ def antiparallel(t):
     return numpy.dot(fn1,fn2) == -1
 
 def precision(x): 
-    front, back = (p for p in str(x).split('.'))
-    if front != '0': return -len(front)
-    elif back != '0': return len(back)
-    else: return 0
+    return -numpy.floor(numpy.log10(x))
 
 def recursive_connections(Over2_connected_points):
     for entry, connectedpointentry in Over2_connected_points.items():

--- a/Tools/blender_3dmigoto_gimi.py
+++ b/Tools/blender_3dmigoto_gimi.py
@@ -1543,19 +1543,21 @@ def export_3dmigoto_genshin(operator, context, object_name, vb_path, ib_path, fm
                         vertex = vertex_group[0]
                     
                         vertex_group_set = set(vertex_group)
+                        
+                        FacesConnectedbySameVertex = Precalculated_Outline_data.get('Connected_Faces_bySameVertex').get(vertex)
                     
-                        ConnectedFaces = [mesh.polygons[x].vertices for x in Precalculated_Outline_data.get('Connected_Faces_bySameVertex').get(vertex)]
+                        ConnectedFaces = [mesh.polygons[x].vertices for x in FacesConnectedbySameVertex]
                         ConnectedFaceNormals = []
                         ConnectedWeightedNormal = []
                         
                         if checkEnclosedFacesVertex(ConnectedFaces, vertex_group_set, Precalculated_Outline_data):
-                            ConnectedFaceNormals = [mesh.polygons[x].normal for x in Precalculated_Outline_data.get('Connected_Faces_bySameVertex').get(vertex)]
+                            ConnectedFaceNormals = [mesh.polygons[x].normal for x in FacesConnectedbySameVertex]
                             
                             AntiP = filter(antiparallel, itertools.product(ConnectedFaceNormals, ConnectedFaceNormals)) 
                             
                             if not any(AntiP):
                             
-                                for facei in Precalculated_Outline_data.get('Connected_Faces_bySameVertex').get(vertex):
+                                for facei in FacesConnectedbySameVertex:
                                     face = mesh.polygons[facei]
                                     vlist = set(face.vertices)
                                     


### PR DESCRIPTION
Removed ignore_tangent and related programs.
Minor variable assignment change.
Duplicated the blender_vertex_to_3dmigoto_vertex function in order to preserve the original functionality and speed at the price of a few lines of more storage consumption.
Added a couple control options for outlines on export mod folder panel.
Could possibly work on improving the outline calculation algorithm for more speed, but it is fast enough as is...