### PR TITLE
File Not Found while reading resource Error solved

### DIFF
--- a/Tools/genshin_merge_mods.py
+++ b/Tools/genshin_merge_mods.py
@@ -321,9 +321,14 @@ def enable_ini(path):
     for root, dir, files in os.walk(path):
         for file in files:
             if os.path.splitext(file)[1] == ".ini" and ("disabled" in root.lower() or "disabled" in file.lower()):
-                print(f"\tRe-enabling {os.path.join(root, file)}")
-                new_path = re.compile("disabled", re.IGNORECASE).sub("", os.path.join(root, file))
-                os.rename(os.path.join(root, file), new_path)
+                path = os.path.join(root, file)
+                print(f"\tRe-enabling {path}")
+                new_path = re.compile("disabled", re.IGNORECASE).sub("", path)
+                # If enabled ini already exists -> Replace
+                if (os.path.exists(new_path)):
+                    os.replace(path, new_path)
+                else: # Rename if not
+                    os.rename(path, new_path)
 
 
 # Gets the user's preferred order to merge mod files


### PR DESCRIPTION
Script gives "File Not Found Error" while reading resource.
The mod merger script gives me a File Not Found error while reading a file that doesn't exist.
My mod is an Ayaka Skin with a mask like Kuki, and I think the mask is the resouce not found in a No-Mask Variant.

The enable arg needs to check if enabled .ini already exists to not trigger file renaming error.
I made enabled .ini to be replaced with new enabled one.
Example:
DISABLE_merged.ini
merged.ini (delete this and replace with the other)